### PR TITLE
Removed redundant variable assignments, causing string extension

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -9,8 +9,8 @@ CANDLE_MODEL=train.py
 
 ### Set env if CANDLE_MODEL is not in same directory as this script
 IMPROVE_MODEL_DIR=${IMPROVE_MODEL_DIR:-$( dirname -- "$0" )}
-
 CANDLE_MODEL=${IMPROVE_MODEL_DIR}/${CANDLE_MODEL}
+
 if [ ! -f ${CANDLE_MODEL} ] ; then
     echo No such file ${CANDLE_MODEL}
     exit 404
@@ -49,16 +49,17 @@ elif [ $# -ge 3 ] ; then
 fi
 
 
-# Set env if CANDLE_MODEL is not in same directory as this script
-IMPROVE_MODEL_DIR=${IMPROVE_MODEL_DIR:-$( dirname -- "$0" )}
 
-# Combine path and name and check if executable exists
-CANDLE_MODEL=${IMPROVE_MODEL_DIR}/${CANDLE_MODEL}
+# Set env if CANDLE_MODEL is not in same directory as this script
+echo COMMAND: ${CMD}
+echo $IMPROVE_MODEL_DIR
+echo $CANDLE_MODEL
+
 if [ ! -f ${CANDLE_MODEL} ] ; then
 	echo No such file ${CANDLE_MODEL}
 	exit 404
 fi
-
+echo COMMAND: ${CMD}
 
 if [ -d ${IMPROVE_MODEL_DIR} ]; then
     if [ "$(ls -A ${CANDEL_DATA_DIR})" ] ; then


### PR DESCRIPTION
closes #28 

Command: `sh DrugCell/train.sh 1 DrugCell/tmp --epochs 1`
Status: OK

Output:
```
INFO:DrugCell:== Epoch [0/1] ==
INFO:DrugCell:   **** TRAINING ****   Epoch [1/1], loss: 31.31487. This took 34.9 secs.
INFO:DrugCell:   **** TEST ****   Epoch [1/1], loss: 766.21169. This took 39.8 secs.
Best performed model (epoch)    0
{'test_loss': 766.2116885185242, 'test_pcc': nan, 'test_MSE': 0.8518998026847839, 'test_r2': -17.928861618041992, 'test_scc': 1.0, 'IMPROVE RESULT': 0.8518998026847839}

IMPROVE_RESULT MSE:     0.8518998026847839
```